### PR TITLE
Add a `sync_today` flag to not disrupt any existing Zoom tap behavior

### DIFF
--- a/tap_zoom/client.py
+++ b/tap_zoom/client.py
@@ -37,8 +37,7 @@ class ZoomClient(object):
             in for the current day. 
             
             NOTE: Since the Zoom API only takes dates (instead of timestamps) for the 
-            date ranges when requesting recordings, the share_url for the current 
-            dates are not stable. Therefore make sure to also use the url_to_recordings
+            date ranges when requesting recordings, the share_url for today is not stable. Therefore make sure to also use the url_to_recordings
             to map share_url to a stable uuid: https://github.com/Pathlight/tap-zoom/pull/5
         """
         self.sync_today = config.get('sync_today', False)

--- a/tap_zoom/client.py
+++ b/tap_zoom/client.py
@@ -32,6 +32,16 @@ class ZoomClient(object):
         self.__use_jwt = False
         self.__expires_at = None
         self.start_date = config.get('start_date')
+        """
+            Add the `sync_today` flag if you want to also ingest data as it's coming
+            in for the current day. 
+            
+            NOTE: Since the Zoom API only takes dates (instead of timestamps) for the 
+            date ranges when requesting recordings, the share_url for the current 
+            dates are not stable. Therefore make sure to also use the url_to_recordings
+            to map share_url to a stable uuid: https://github.com/Pathlight/tap-zoom/pull/5
+        """
+        self.sync_today = config.get('sync_today', False)
 
         jwt = config.get('jwt')
         refresh_token = config.get('refresh_token')


### PR DESCRIPTION
This was left as a dangling change since we deprioritized improving the Zoom tap for our internal Pathlight instance.

Basically, I made the two following changes:
- https://github.com/Pathlight/tap-zoom/pull/4
- https://github.com/Pathlight/tap-zoom/pull/5

We have two existing zoom taps which don't need to sync the current date and the deployed version of the Zoom tap doesn't include these updated changes (we're still using version 1.0.0 [here](https://github.com/Pathlight/lloyd/blob/master/taps/zoom/Dockerfile#L7)). I wanted to make this a flag so when we do make any new Zoom tap changes (ex. add Zoom phone APIs for this [ticket](https://pathlighthq.atlassian.net/browse/FUJ-5821)), then these changes don't get accidentally deployed and disrupt the production taps.

So the steps if you want to ingest today's data, you need to:
- Add `sync_today: True` to the tap config
- Also add the `url_to_recordings` stream to the catalog and update any reports to point to the stable uuid

---

Tested locally. 

(1) When the `sync_today` flag is not enabled (defaulted to false)
- No data synced because `start_datetime == max_datetime` (aka today). This is the old default behavior
```
...
{"type": "STATE", "value": {"bookmarks": {"recordings": {"endDate": "2023-11-02"}}, "currently_syncing": "recordings"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 33, "tags": {"endpoint": "users"}}
{"type": "STATE", "value": {"bookmarks": {"recordings": {"endDate": "2023-11-02"}}, "currently_syncing": null}}
```

(2) When the `sync_today` flag is enabled
- Recordings from today (11/2/2023) are ingested
```
...
{"type": "RECORD", "stream": "recordings", "record": {"uuid": "5hIcHJppSXi8nA3Vexlo2g==", "id": 86581266871, "account_id": "LQGkHZrASq-EN2KnM2Ez5Q", "host_id": "_nbV9Cm0SIySg2AYbvgtSQ", "topic": "Google Calendar Meeting (not synced)", "type": 2, "start_time": "2023-11-02T20:00:33.000000Z", "timezone": "America/Los_Angeles", "duration": 19, "total_size": 247168471, "recording_count": 4, ... "status": "completed", "recording_type": "active_speaker"}]}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 1, "tags": {"endpoint": "recordings"}}
{"type": "SCHEMA", "stream": "recordings", "schema": {"properties": {"id": {"type": ["integer"]}, "type": {"type": ["integer"]}, "uuid": {"type": ["string"]}, "topic": {"type": ["string"]}, "host_id": {"type": ["string"]}, "duration": {"type": ["integer", "null"]}, "timezone": {"type": ["string", "null"]}, "share_url": {"type": ["string"]}, "account_id": {"type": ["string"]}, "start_time": {"format": "date-time", "type": ["string", "null"]}, "total_size": {"type": ["integer", "null"]}, "recording_count": {"type": ["integer", "null"]}, "recording_files": {"items": {"properties": {"id": {"type": ["string"]}, "status": {"type": ["string"]}, "play_url": {"type": ["string", "null"]}, "file_path": {"type": ["null", "string"]}, "file_size": {"type": ["integer"]}, "file_type": {"type": ["string"]}, "meeting_id": {"type": ["string", "null"]}, "deleted_time": {"type": ["null", "string"]}, "download_url": {"type": ["string", "null"]}, "recording_end": {"format": "date-time", "type": ["string", "null"]}, "file_extension": {"type": ["string"]}, "recording_type": {"type": ["string"]}, "recording_start": {"format": "date-time", "type": ["string", "null"]}}, "type": ["object"], "additionalProperties": false}, "type": ["array", "null"]}}, "type": "object", "additionalProperties": false}, "key_properties": ["uuid"]}
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.18665599822998047, "tags": {"endpoint": "recordings", "http_status_code": 200, "status": "succeeded"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 0, "tags": {"endpoint": "recordings"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 33, "tags": {"endpoint": "users"}}
{"type": "STATE", "value": {"bookmarks": {"recordings": {"endDate": "2023-11-02"}}, "currently_syncing": null}}
```